### PR TITLE
Create 1920. Build Array from Permutation

### DIFF
--- a/Array/1920. Build Array from Permutation
+++ b/Array/1920. Build Array from Permutation
@@ -1,0 +1,78 @@
+1920. Build Array from Permutation
+DESCRIPTION
+Given a zero-based permutation nums (0-indexed), build an array ans of the same length where ans[i] = nums[nums[i]] for each 0 <= i < nums.length and return it.
+A zero-based permutation nums is an array of distinct integers from 0 to nums.length - 1 (inclusive).
+
+Example 1:
+Input: nums = [0,2,1,5,3,4]
+Output: [0,1,2,4,5,3]
+Explanation: The array ans is built as follows: 
+ans = [nums[nums[0]], nums[nums[1]], nums[nums[2]], nums[nums[3]], nums[nums[4]], nums[nums[5]]]
+    = [nums[0], nums[2], nums[1], nums[5], nums[3], nums[4]]
+    = [0,1,2,4,5,3]
+
+Example 2:
+Input: nums = [5,0,1,2,3,4]
+Output: [4,5,0,1,2,3]
+Explanation: The array ans is built as follows:
+ans = [nums[nums[0]], nums[nums[1]], nums[nums[2]], nums[nums[3]], nums[nums[4]], nums[nums[5]]]
+    = [nums[5], nums[0], nums[1], nums[2], nums[3], nums[4]]
+    = [4,5,0,1,2,3]
+ 
+
+Constraints:
+1 <= nums.length <= 1000
+0 <= nums[i] < nums.length
+The elements in nums are distinct.
+
+SOLUTION
+JAVA
+class Solution {
+    public int[] buildArray(int[] nums) {
+        int n = nums.length;
+        
+        for (int i = 0; i < n; i++) {
+            nums[i] = (nums[nums[i]] % n) * n + nums[i];
+        }
+        
+        for (int i = 0; i < n; i++) {
+            nums[i] = nums[i] / n;
+        }
+        
+        return nums;
+    }
+}
+
+C++
+class Solution {
+public:
+    vector<int> buildArray(vector<int>& nums) {
+        vector<int> ans(nums.size());
+        for(int i=0;i<nums.size();i++){
+            ans[i]=nums[nums[i]];
+        }
+        return ans; 
+    }
+};
+
+PYTHON/PYTHON3
+class Solution:
+    def buildArray(self, nums: List[int]) -> List[int]:
+        ans=[0]*len(nums)
+        for i in range(len(nums)):
+            ans[i]=nums[nums[i]]
+        return ans
+
+C
+/**
+ * Note: The returned array must be malloced, assume caller calls free().
+ */
+int* buildArray(int* nums, int numsSize, int* returnSize) {
+        int* ans = (int*)malloc(numsSize * sizeof(int));
+        for(int i=0;i<numsSize;i++){
+            ans[i]=nums[nums[i]];
+        }
+        *returnSize = numsSize;
+        return ans;
+}
+


### PR DESCRIPTION
Given a zero-based permutation nums (0-indexed), build an array ans of the same length where ans[i] = nums[nums[i]] for each 0 <= i < nums.length and return it.

A zero-based permutation nums is an array of distinct integers from 0 to nums.length - 1 (inclusive).

 

Example 1:

Input: nums = [0,2,1,5,3,4]
Output: [0,1,2,4,5,3]
Explanation: The array ans is built as follows: 
ans = [nums[nums[0]], nums[nums[1]], nums[nums[2]], nums[nums[3]], nums[nums[4]], nums[nums[5]]]
    = [nums[0], nums[2], nums[1], nums[5], nums[3], nums[4]]
    = [0,1,2,4,5,3]
Example 2:

Input: nums = [5,0,1,2,3,4]
Output: [4,5,0,1,2,3]
Explanation: The array ans is built as follows:
ans = [nums[nums[0]], nums[nums[1]], nums[nums[2]], nums[nums[3]], nums[nums[4]], nums[nums[5]]]
    = [nums[5], nums[0], nums[1], nums[2], nums[3], nums[4]]
    = [4,5,0,1,2,3]
 

Constraints:

1 <= nums.length <= 1000
0 <= nums[i] < nums.length
The elements in nums are distinct.